### PR TITLE
Fix cross-repo schema_version contract: write canonical nested location

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -323,17 +323,20 @@ jobs:
                       for e in errors: print(" -", e)
                       sys.exit(1)
 
-                  # Contract-marker regression guard (0.2.33). Assert the
-                  # server stamps schema_version: 1 and backfills a
-                  # properties.id for every feature that hit the save path
-                  # above — the HA integration binds automations to id
-                  # across renames, so a regression here silently breaks
-                  # downstream bindings.
+                  # Contract-marker regression guard. Assert the server stamps
+                  # schema_version: 1 in the canonical foreign-member location
+                  # (polygonal_zones.schema_version, per docs/ZONES_FORMAT.md —
+                  # this is what the HA integration reads) and NOT bare
+                  # top-level, plus backfills a properties.id for every feature
+                  # that hit the save path above — the integration binds
+                  # automations to id across renames, so a regression here
+                  # silently breaks downstream bindings.
                   persisted = await page.evaluate(
                       "async () => (await fetch('./zones.json').then(r => r.json()))"
                   )
-                  if persisted.get("schema_version") != 1:
-                      print(f"FAIL schema_version missing or wrong on persisted file: {persisted.get('schema_version')!r}")
+                  persisted_version = (persisted.get("polygonal_zones") or {}).get("schema_version")
+                  if persisted_version != 1 or "schema_version" in persisted:
+                      print(f"FAIL schema_version must be at polygonal_zones.schema_version==1 and not top-level; got nested={persisted_version!r}, top_level_present={'schema_version' in persisted}")
                       for e in errors: print(" -", e)
                       sys.exit(1)
                   for idx, feat in enumerate(persisted.get("features") or []):

--- a/polygonal_zones_editor/app/main.py
+++ b/polygonal_zones_editor/app/main.py
@@ -296,11 +296,16 @@ def _validate_feature_collection(obj) -> None:
         raise ValueError("expected a GeoJSON FeatureCollection")
 
     # schema_version is optional on input for backward compatibility with
-    # curl-restored pre-versioned files. When present it must be an int.
-    # isinstance(True, int) is True in Python because bool subclasses int,
-    # so reject bool explicitly — a consumer doing `schema_version >= 1`
-    # shouldn't silently pass on `True`.
-    schema_version = obj.get("schema_version")
+    # curl-restored pre-versioned files. The canonical location is the foreign
+    # member ``polygonal_zones.schema_version`` (matching the spec and the
+    # companion integration's reader); a bare top-level ``schema_version`` is
+    # accepted only as a legacy fallback for files written before this fix.
+    # When present it must be an int. isinstance(True, int) is True in Python
+    # because bool subclasses int, so reject bool explicitly — a consumer
+    # doing `schema_version >= 1` shouldn't silently pass on `True`.
+    pz_in = obj.get("polygonal_zones")
+    nested_version = pz_in.get("schema_version") if isinstance(pz_in, dict) else None
+    schema_version = nested_version if nested_version is not None else obj.get("schema_version")
     if schema_version is not None and (
         isinstance(schema_version, bool) or not isinstance(schema_version, int)
     ):
@@ -392,7 +397,17 @@ def _normalise_feature_collection(obj: dict) -> dict:
     stable `properties.id` the companion integration can bind automations
     to across renames. Mutates and returns ``obj``.
     """
-    obj["schema_version"] = SCHEMA_VERSION
+    # Stamp the canonical foreign-member location the integration reads
+    # (polygonal_zones.schema_version per docs/ZONES_FORMAT.md). Earlier
+    # builds wrote a bare top-level key the integration never read, so a
+    # future schema bump would have silently bypassed its version guard.
+    pz = obj.get("polygonal_zones")
+    if not isinstance(pz, dict):
+        pz = {}
+        obj["polygonal_zones"] = pz
+    pz["schema_version"] = SCHEMA_VERSION
+    # Drop any legacy top-level key so there is a single source of truth.
+    obj.pop("schema_version", None)
     for feature in obj.get("features", []):
         props = feature.get("properties")
         if not isinstance(props, dict):

--- a/polygonal_zones_editor/tests/test_main.py
+++ b/polygonal_zones_editor/tests/test_main.py
@@ -228,8 +228,10 @@ def test_save_zones_persists_valid_geojson(allow_all_client, tmp_zones_file):
         # id was backfilled (uuid4.hex = 32 chars of hex)
         assert isinstance(got["properties"]["id"], str)
         assert len(got["properties"]["id"]) == 32
-    # schema_version stamped.
-    assert stored["schema_version"] == 1
+    # schema_version stamped in the canonical foreign-member location the
+    # companion integration reads (docs/ZONES_FORMAT.md), NOT bare top-level.
+    assert stored["polygonal_zones"]["schema_version"] == 1
+    assert "schema_version" not in stored
 
 
 def test_save_zones_preserves_client_supplied_id(allow_all_client, tmp_zones_file):
@@ -310,6 +312,25 @@ def test_save_zones_accepts_valid_schema_version(allow_all_client, tmp_zones_fil
     payload = {**_valid_payload(), "schema_version": 1}
     r = allow_all_client.post("/save_zones", json=payload)
     assert r.status_code == 200
+
+
+def test_save_zones_accepts_nested_schema_version(allow_all_client, tmp_zones_file):
+    """The canonical input location is the foreign member; a nested value is
+    validated and re-stamped nested (never duplicated top-level)."""
+    payload = {**_valid_payload(), "polygonal_zones": {"schema_version": 1}}
+    r = allow_all_client.post("/save_zones", json=payload)
+    assert r.status_code == 200
+    stored = json.loads(tmp_zones_file.read_text())
+    assert stored["polygonal_zones"]["schema_version"] == 1
+    assert "schema_version" not in stored
+
+
+def test_save_zones_rejects_non_int_nested_schema_version(allow_all_client, tmp_zones_file):
+    """A bad value in the canonical nested location is rejected, not ignored."""
+    payload = {**_valid_payload(), "polygonal_zones": {"schema_version": "oops"}}
+    r = allow_all_client.post("/save_zones", json=payload)
+    assert r.status_code == 422
+    assert "schema_version" in r.json()["detail"]
 
 
 def test_save_zones_rejects_non_string_id(allow_all_client, tmp_zones_file):


### PR DESCRIPTION
Panel P0 (chief-architect / lead-backend / data-engineer / qa-lead — 4-way consensus).

## Problem
The add-on stamped a **bare top-level** `schema_version` (`main.py`), but the spec (`docs/ZONES_FORMAT.md`) and the companion integration's reader (`utils/zones.py`) use the foreign member **`polygonal_zones.schema_version`**. So the integration never saw the add-on's marker and always assumed implicit v1. Harmless while both are v1 — but the **first schema bump would silently bypass the integration's 'reject newer file' guard**, misparsing newer files with no error.

## Fix
- **main.py**: write `polygonal_zones.schema_version` (drop the legacy top-level key so there's a single source of truth); validator reads the nested location (canonical) with a top-level fallback for files written before this fix.
- **build.yml**: draw→save smoke now asserts the nested marker (codex caught this — it would otherwise fail the gate).
- **tests**: nested write/read coverage added; existing legacy-top-level input tests retained.

## Verified
141 tests pass at 100% coverage on Python 3.14. Dual-reviewed (Claude + codex); codex's build.yml finding addressed here.

> Pairs with integration-side reader (already correct). No integration change needed.