### PR TITLE
Editor: label the per-row commit button 'Done' not 'Save'

### DIFF
--- a/polygonal_zones_editor/app/static/js/zone-entry.js
+++ b/polygonal_zones_editor/app/static/js/zone-entry.js
@@ -151,7 +151,12 @@ class ZoneEntry extends HTMLElement {
 
         let edit_button = document.createElement('button');
         edit_button.classList.add('edit-btn');
-        edit_button.innerText = !editing ? 'Edit' : 'Save';
+        // "Done" (not "Save") for the per-row commit: it only confirms this
+        // zone's name into the in-memory layer. The sidebar "Save" is the file
+        // write. Sharing the "Save" label made users think the row button
+        // persisted to disk, then leave without the sidebar Save and lose the
+        // rename.
+        edit_button.innerText = !editing ? 'Edit' : 'Done';
         edit_button.onclick = this.edit_event_handler.bind(this);
 
         if (!editing) {


### PR DESCRIPTION
Product-designer panel finding (flagged in two independent panels).

The zone-**row** button and the **sidebar** button both read "Save" but do different things — the row button commits a rename into the in-memory layer; the sidebar button writes the file. Users pressed the row "Save", assumed it persisted, left without the sidebar Save, and **lost the rename** (likely the top future data-loss bug report).

Change: row button → **"Done"** (the standard Edit/Done inline-edit pattern). Sidebar keeps "Save" (file write). `innerText` is the button's accessible name, so the screen-reader label updates too. The build.yml smoke clicks `.edit-btn` by class, so it's unaffected.

One-line change; no logic touched.

> Per maintainer policy this addon runtime change needs a local docker build + boot before merge — I'll run that when merging.