### PR TITLE
Security: quiet uvicorn access-log + drop allow_all_ips argv branch (closes #11)

### DIFF
--- a/polygonal_zones_editor/app/helpers.py
+++ b/polygonal_zones_editor/app/helpers.py
@@ -44,8 +44,14 @@ def configure_logging(level: int = logging.INFO) -> None:
 
 
 def allow_all_ips(options: dict) -> bool:
-    """Check if the --allow-all-ips flag is passed or enabled in the options."""
-    return '--allow-all-ips' in sys.argv or '-a' in sys.argv or options.get('allow_all_ips', False)
+    """Whether unauthenticated access from any client IP is enabled.
+
+    Options-only. The previous ``sys.argv`` (``--allow-all-ips`` / ``-a``)
+    branch was removed: an auth-bypass switch keyed on process arguments is
+    fragile and surprising, and the shipped s6 service invokes the app with no
+    such flags. Configure via the add-on's ``allow_all_ips`` option instead.
+    """
+    return bool(options.get('allow_all_ips', False))
 
 
 def allowed_ip(request: Request) -> bool:

--- a/polygonal_zones_editor/app/main.py
+++ b/polygonal_zones_editor/app/main.py
@@ -644,6 +644,11 @@ def generate_app(options: dict) -> tuple[Starlette, dict]:
     log_config = uvicorn.config.LOGGING_CONFIG
     log_config["version"] = 1
     log_config["disable_existing_loggers"] = False
+    # Quiet the access log: uvicorn's default access logger records the client
+    # IP + request line for every request at INFO, which the Supervisor add-on
+    # log surfaces to any HA user. Client IP is personal data (GDPR Recital 30)
+    # and the add-on log has no retention control, so raise it to WARNING.
+    log_config.setdefault("loggers", {}).setdefault("uvicorn.access", {})["level"] = "WARNING"
 
     middleware = [
         Middleware(IPAllowMiddleware, options=options),

--- a/polygonal_zones_editor/tests/test_helpers.py
+++ b/polygonal_zones_editor/tests/test_helpers.py
@@ -4,18 +4,13 @@ import sys
 import pytest
 
 
-def test_allow_all_ips_long_flag(monkeypatch):
+def test_allow_all_ips_ignores_argv_flags(monkeypatch):
+    """The legacy --allow-all-ips / -a argv flags no longer grant access;
+    allow_all_ips is options-only now."""
     import helpers
 
-    monkeypatch.setattr(sys, "argv", ["main.py", "--allow-all-ips"])
-    assert helpers.allow_all_ips({}) is True
-
-
-def test_allow_all_ips_short_flag(monkeypatch):
-    import helpers
-
-    monkeypatch.setattr(sys, "argv", ["main.py", "-a"])
-    assert helpers.allow_all_ips({}) is True
+    monkeypatch.setattr(sys, "argv", ["main.py", "--allow-all-ips", "-a"])
+    assert helpers.allow_all_ips({}) is False
 
 
 def test_allow_all_ips_from_options(monkeypatch):


### PR DESCRIPTION
**Closes #11** (DPO + security panels).

- **uvicorn access-log → WARNING** (`main.py`): the default access log records **client IP** + request line at INFO for every request, which the Supervisor add-on log shows to any HA user, with no retention control. Client IP is personal data.
- **`allow_all_ips` is options-only** (`helpers.py`): removed the `sys.argv` (`--allow-all-ips`/`-a`) branch — an auth-bypass switch keyed on process arguments is fragile and surprising; the shipped s6 service passes no such flags. Test now asserts argv flags are ignored.

Addon suite: 140 pass, 100% coverage. Dual-reviewed (Claude + codex). 

> Add-on runtime change → I'll do a local docker build + boot before merging, per policy.