### PR TITLE
CI: aarch64 boot-smoke + branch coverage (closes #12)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,16 +87,16 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # Smoke-test the amd64 image only — it can be loaded into the runner's
-      # docker daemon without QEMU. Verifies the addon actually boots under a
-      # Supervisor-style /data mount (root-owned options.json), which would
-      # have caught the regressions in 0.2.0 and 0.2.1.
-      - name: Build amd64 smoke image
-        if: matrix.arch == 'amd64'
+      # Smoke-test every arch. amd64 loads + runs natively; aarch64 loads and
+      # runs via the QEMU binfmt set up above (slower, but catches arm64-specific
+      # boot regressions before they reach RPi / HA Yellow / HA Green users).
+      # Verifies the addon boots under a Supervisor-style /data mount (root-owned
+      # options.json), which would have caught the regressions in 0.2.0 and 0.2.1.
+      - name: Build smoke image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ./polygonal_zones_editor
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           build-args: |
             BUILD_FROM=${{ matrix.base }}
           load: true
@@ -104,7 +104,6 @@ jobs:
           cache-from: type=gha
 
       - name: Boot container and probe endpoints
-        if: matrix.arch == 'amd64'
         run: |
           set -euo pipefail
           DATA=$(mktemp -d)
@@ -114,13 +113,14 @@ jobs:
 
           docker run -d --name smoke -p 8000:8000 -v "$DATA":/data polygonal-zones:smoke
 
-          # Wait up to 30s for /healthz.
-          for i in $(seq 1 30); do
+          # Wait up to 90s for /healthz (generous headroom: aarch64 boots under
+          # QEMU emulation, which is much slower than the native amd64 run).
+          for i in $(seq 1 90); do
             if curl -fsS http://127.0.0.1:8000/healthz | grep -q ok; then
               echo "OK /healthz responded on attempt $i"
               break
             fi
-            if [ "$i" = "30" ]; then
+            if [ "$i" = "90" ]; then
               echo "FAIL /healthz never responded"
               docker logs smoke
               exit 1

--- a/polygonal_zones_editor/pytest.ini
+++ b/polygonal_zones_editor/pytest.ini
@@ -10,5 +10,6 @@ testpaths = tests
 # immediately actionable.
 addopts =
     --cov=app
+    --cov-branch
     --cov-report=term-missing
     --cov-fail-under=100


### PR DESCRIPTION
**Closes #12** (SRE + QA panels).

- **aarch64 boot-smoke** (`build.yml`): the boot + endpoint-probe step now runs for **every arch** (was amd64-only). aarch64 is built `--load` and booted through the QEMU binfmt already configured, catching arm64-specific boot/runtime regressions before they reach RPi / HA Yellow / HA Green. `/healthz` wait widened to 90s for emulation; the heavy Playwright browser smoke stays amd64-only.
- **Branch coverage** (`pytest.ini`): added `--cov-branch` — the 100% gate now covers branches too (already 138/138, no test changes needed).

addon suite: 140 pass at 100% line **+ branch** coverage. Dual-reviewed (Claude + codex). CI YAML + test config (CI-sufficient per policy); the PR's own CI run exercises the new aarch64 smoke.