### PR TITLE
Editor UX: contrast, mobile, touch target, render/naming/inline-error fixes (part of #10)

### DIFF
--- a/polygonal_zones_editor/app/static/css/style.css
+++ b/polygonal_zones_editor/app/static/css/style.css
@@ -27,7 +27,7 @@
 @media (prefers-color-scheme: dark) {
     :root:not([data-theme="light"]) {
         --sidebar-color: #1f1f1f;
-        --save-button-color: #3a86ff;
+        --save-button-color: #1a5fb4;
         --save-button-text: #ffffff;
         --text-color: #e8e8e8;
         --muted-text: #aaaaaa;
@@ -44,7 +44,7 @@
 /* Forced dark (theme=dark option) overrides regardless of OS preference. */
 :root[data-theme="dark"] {
     --sidebar-color: #1f1f1f;
-    --save-button-color: #3a86ff;
+    --save-button-color: #1a5fb4;
     --save-button-text: #ffffff;
     --text-color: #e8e8e8;
     --muted-text: #aaaaaa;
@@ -165,8 +165,8 @@ body {
     position: fixed;
     top: 10px;
     z-index: 1000;          /* above Leaflet's controls (z-index ≤ 800) */
-    width: 32px;
-    height: 32px;
+    width: 44px;            /* WCAG 2.5.5 / iOS HIG minimum touch target */
+    height: 44px;
     border: 1px solid var(--border-color);
     border-radius: 4px;
     background: var(--sidebar-color);
@@ -258,12 +258,15 @@ body {
     transition: 0.3s;
 }
 
+/* WCAG AA contrast with white button text: plain `green`/`red` were ~3.4–4.0:1
+   (below 4.5:1). These darker shades clear AA on the button's light + dark
+   backgrounds. */
 .save-btn.success {
-    background-color: green !important;
+    background-color: #1a7f37 !important;
 }
 
 .save-btn.error {
-    background-color: red !important;
+    background-color: #c0392b !important;
 }
 
 
@@ -343,5 +346,54 @@ body {
 
 .tile-error-banner[hidden] {
     display: none;
+}
+
+/* Transient error toast (e.g. invalid bulk JSON). Top-anchored with a z-index
+   above the mobile bottom-sheet sidebar (1100) so the message is never hidden
+   behind the drawer on narrow viewports. */
+.transient-error {
+    position: fixed;
+    top: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1200;
+    max-width: 90vw;
+    background: var(--popup-bg);
+    color: var(--text-color);
+    border: 1px solid var(--border-color);
+    padding: 8px 16px;
+    border-radius: 2px;
+    font-size: 0.9em;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+}
+
+/* Mobile / narrow viewport. A fixed 300px sidebar leaves the map unusable on a
+   phone, so below 600px the sidebar becomes a bottom sheet over a full-width
+   map. Overrides the desktop grid regardless of the data-sidebar state (except
+   "collapsed", which still hides it). */
+@media (max-width: 600px) {
+    .body[data-sidebar="open"],
+    .body[data-sidebar="drawer"] {
+        grid-template-columns: 1fr;
+    }
+
+    .body[data-sidebar="open"] .sidebar,
+    .body[data-sidebar="drawer"] .sidebar {
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        width: auto;
+        max-height: 45vh;
+        overflow-y: auto;
+        z-index: 1100;          /* above the map + sidebar toggle */
+        border-top: 1px solid var(--border-color);
+        box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.25);
+    }
+
+    /* Keep the toggle reachable above the bottom sheet. */
+    .body[data-sidebar="open"] .sidebar-toggle {
+        right: 10px;
+    }
 }
 

--- a/polygonal_zones_editor/app/static/js/map.js
+++ b/polygonal_zones_editor/app/static/js/map.js
@@ -340,8 +340,10 @@ function setup_editing(map, editableLayers) {
         let layers = e.layers;
         layers.eachLayer(layer => {
             editableLayers.removeLayer(layer);
-            render_zone_list();
         });
+        // Rebuild the list once, after all removals — deleting N zones used to
+        // trigger N full DOM rebuilds of the entire zone list.
+        render_zone_list();
         mark_dirty();
 
         if (editableLayers.getLayers().length === 0) {
@@ -357,8 +359,15 @@ function setup_editing(map, editableLayers) {
             layer.bindPopup('A popup!');
         }
 
-        // generate a name according to `zone {n}`
-        let name = `Zone ${editableLayers.getLayers().length + 1}`;
+        // Generate a unique "Zone N" name. Layer-count + 1 collided after
+        // deletions (delete zone 2 of 3, draw a new one → "Zone 3" duplicated
+        // the renamed one). Use one past the highest existing "Zone N" instead.
+        let maxN = 0;
+        editableLayers.eachLayer(l => {
+            let m = /^Zone (\d+)$/.exec(l.feature?.properties?.name ?? '');
+            if (m) maxN = Math.max(maxN, parseInt(m[1], 10));
+        });
+        let name = `Zone ${maxN + 1}`;
         // `type: 'Feature'` is required. Leaflet's toGeoJSON() uses this
         // object as a template — when `layer.feature` is already set it
         // extends it with a `geometry` field but does NOT auto-add the
@@ -522,6 +531,17 @@ function save_zones() {
 }
 
 
+function show_transient_error(message) {
+    // alert() is unreliable inside Home Assistant's ingress iframe (sandboxed
+    // dialogs may be suppressed), so surface errors as an in-page banner.
+    let el = document.createElement('div');
+    el.setAttribute('role', 'alert');
+    el.className = 'transient-error';
+    el.textContent = message;
+    document.body.appendChild(el);
+    setTimeout(() => el.remove(), 5000);
+}
+
 function load_bulk_json() {
     // open a file dialog
     let input = document.createElement('input');
@@ -534,7 +554,7 @@ function load_bulk_json() {
             let data;
             try { data = JSON.parse(e.target.result); }
             catch (err) {
-                alert('The selected file is not valid JSON.');
+                show_transient_error('The selected file is not valid JSON.');
                 return;
             }
             editableLayers.clearLayers();


### PR DESCRIPTION
Addresses **#10** (partial — see remaining below).

## Fixed
- **WCAG contrast**: save-button success/error + dark `--save-button-color` were below AA on white text → darker accessible shades.
- **44px touch target** for the sidebar toggle (WCAG 2.5.5).
- **Mobile**: `@media (max-width: 600px)` turns the fixed 300px sidebar into a full-width **bottom sheet** so the editor is usable on phones/tablets.
- **Multi-delete render**: rebuild the zone list **once** after N removals (was once per zone).
- **Unique auto-naming**: `Zone N` now picks one past the highest existing N (count+1 collided after deletions).
- **`alert()` → inline banner**: alerts are suppressed in HA's ingress iframe; replaced with an in-page transient error, z-indexed above the mobile sheet (codex catch).

## Verified
Local docker build + boot on the 3.21 base (boots clean, changed assets served, endpoints 200); the add-on's **Playwright smoke** (CI) exercises draw→save + asserts no JS console errors. Dual-reviewed (Claude + codex). *(Chrome extension was offline, so the dynamic browser check is the CI headless smoke.)*

## Remaining on #10 (kept open)
- id-based layer lookup (vs name) — needs zone-entry to carry `properties.id` in its edit event
- visible unsaved-changes indicator (the `isDirty` flag exists; no UI dot yet)
- asset-size perf: `adoptedStyleSheets`, minified/gzipped Leaflet
- empty-vs-loading state distinction