### PR TITLE
Editor UX (#10, part 2): id-based lookup, dirty indicator, empty/loading states, gzip

### DIFF
--- a/polygonal_zones_editor/app/main.py
+++ b/polygonal_zones_editor/app/main.py
@@ -14,6 +14,7 @@ import uvicorn
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.middleware.gzip import GZipMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, PlainTextResponse, Response
 from starlette.routing import Mount, Route
@@ -653,6 +654,10 @@ def generate_app(options: dict) -> tuple[Starlette, dict]:
     middleware = [
         Middleware(IPAllowMiddleware, options=options),
         Middleware(SecurityHeadersMiddleware),
+        # Innermost: compress text responses (the unminified vendored Leaflet
+        # JS/CSS are the bulk of page weight). Auth/security middleware stay
+        # outermost so they still gate before any work.
+        Middleware(GZipMiddleware, minimum_size=1024),
     ]
 
     app = Starlette(debug=False, routes=routes, middleware=middleware)

--- a/polygonal_zones_editor/app/static/css/style.css
+++ b/polygonal_zones_editor/app/static/css/style.css
@@ -269,6 +269,28 @@ body {
     background-color: #c0392b !important;
 }
 
+/* Unsaved-changes cue inside the Save button. Amber dot shown while isDirty. */
+.dirty-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    margin-right: 6px;
+    border-radius: 50%;
+    background: #f59e0b;
+    vertical-align: middle;
+}
+
+.dirty-dot[hidden] {
+    display: none;
+}
+
+/* Empty zone-list placeholder — distinguishes "no zones" from "still loading". */
+.zone-list-empty {
+    color: var(--muted-text);
+    font-size: 0.9em;
+    margin: 8px 0;
+}
+
 
 .sub-title {
     font-size: 1.2em;

--- a/polygonal_zones_editor/app/static/index.html
+++ b/polygonal_zones_editor/app/static/index.html
@@ -56,7 +56,9 @@
             <h2> Zones </h2>
             <div class="zone-list"></div>
         </div>
-        <button class="save-btn btn" type="button"> Save </button>
+        <button class="save-btn btn" type="button">
+            <span class="dirty-dot" hidden aria-hidden="true"></span>Save
+        </button>
         <p id="save-status" class="sr-only" aria-live="polite" role="status"></p>
 
     </div>

--- a/polygonal_zones_editor/app/static/js/map.js
+++ b/polygonal_zones_editor/app/static/js/map.js
@@ -13,8 +13,15 @@ let zones_etag = null;
 // the beforeunload prompt below so HA's ingress shell can't silently discard
 // unsaved polygons when the user taps another sidebar entry.
 let isDirty = false;
-function mark_dirty() { isDirty = true; }
-function mark_clean() { isDirty = false; }
+function mark_dirty() { isDirty = true; update_dirty_indicator(); }
+function mark_clean() { isDirty = false; update_dirty_indicator(); }
+function update_dirty_indicator() {
+    // Visible (non-screen-reader) cue that there are unsaved changes — the
+    // beforeunload prompt only fires on navigation, which the ingress tab-switch
+    // doesn't trigger, so users had no in-page signal.
+    let dot = document.querySelector('.dirty-dot');
+    if (dot) dot.hidden = !isDirty;
+}
 
 window.addEventListener('beforeunload', (e) => {
     if (!isDirty) return;
@@ -246,6 +253,15 @@ function generate_map(zones_url) {
     let editableLayers = new L.FeatureGroup();
     map.addLayer(editableLayers);
 
+    // Loading affordance so an in-flight fetch is distinguishable from a
+    // genuinely empty zone list. Cleared by render_zone_list() on success or
+    // the error handler below.
+    let _loading_list = document.querySelector('.zone-list');
+    if (_loading_list) {
+        _loading_list.setAttribute('aria-busy', 'true');
+        _loading_list.textContent = 'Loading zones…';
+    }
+
     fetch(zones_url)
         .then(response => {
             if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -283,7 +299,11 @@ function generate_map(zones_url) {
         .catch(err => {
             console.error('Failed to load zones:', err);
             let list = document.querySelector('.zone-list');
-            if (list) list.textContent = 'Failed to load zones — check the log.';
+            if (list) {
+                list.removeAttribute('aria-busy');
+                list.textContent =
+                    "Couldn't load zones. Check the add-on log (Settings → Add-ons → Polygonal Zones → Log).";
+            }
             create_load_btn();
         });
 
@@ -404,7 +424,12 @@ function edit_zone_event(e) {
     document.querySelectorAll('zone-entry').forEach(zone => zone.setAttribute('editing', 'false'));
 
     let oldName = e.detail.oldName || e.detail.name
-    let layer = editableLayers.getLayers().find(layer => layer.feature.properties.name === oldName);
+    // Match on the stable id when we have one (two zones can share a display
+    // name); fall back to name for zones from a pre-versioned file with no id.
+    let layer =
+        (e.detail.id &&
+            editableLayers.getLayers().find(l => l.feature.properties.id === e.detail.id)) ||
+        editableLayers.getLayers().find(l => l.feature.properties.name === oldName);
 
     // if we start editing a zone, enable editing for that zone
     if (e.detail.editing) {
@@ -432,16 +457,33 @@ function shape_count(layer) {
 function render_zone_list() {
     let zone_list = document.querySelector('.zone-list');
     zone_list.innerHTML = '';
+    // Whatever called us has finished loading (this is also the success path of
+    // the initial fetch), so clear the loading affordance.
+    zone_list.removeAttribute('aria-busy');
     editableLayers.eachLayer(layer => {
         // render a zone-entry element and set attribute name
         let zone_entry = document.createElement('zone-entry');
         zone_entry.setAttribute('name', layer.feature.properties.name);
+        // Stable id (if present) so edit events can target the exact layer even
+        // when display names collide.
+        if (layer.feature.properties.id) {
+            zone_entry.setAttribute('zone-id', layer.feature.properties.id);
+        }
         const count = shape_count(layer);
         if (count > 1) zone_entry.setAttribute('shape-count', String(count));
         zone_entry.addEventListener('edit', edit_zone_event);
 
         zone_list.appendChild(zone_entry);
     });
+
+    // Distinct empty state — a blank list otherwise reads identically to a
+    // still-loading one.
+    if (!zone_list.children.length) {
+        let empty = document.createElement('p');
+        empty.className = 'zone-list-empty';
+        empty.textContent = 'No zones yet — draw one on the map to get started.';
+        zone_list.appendChild(empty);
+    }
 }
 
 function save_zones() {

--- a/polygonal_zones_editor/app/static/js/zone-entry.js
+++ b/polygonal_zones_editor/app/static/js/zone-entry.js
@@ -1,87 +1,100 @@
+// The component CSS. Custom properties cascade through the shadow boundary, so
+// the :root theme palette in style.css reaches us automatically.
+const ZONE_ENTRY_CSS = `
+    :host { color: var(--text-color); }
+
+    .hidden {
+        display: none !important;
+    }
+
+    .header {
+        display: flex;
+        justify-content: space-between;
+    }
+
+    .shape-count {
+        opacity: 0.6;
+        font-size: 0.85em;
+        font-weight: normal;
+        margin-left: 0.5ch;
+    }
+
+    .zone-entry {
+        width: 100%;
+        margin-top: 2px;
+        margin-bottom: 2px;
+
+        padding-top: 5px;
+        padding-bottom: 5px;
+    }
+
+    .zone-entry.editing {
+        margin: 5px -10px;
+        padding: 5px 10px;
+        background-color: var(--pz-edit-bg);
+    }
+
+    .zone-entry.editing .header {
+        font-weight: bold;
+    }
+
+    .edit-zone {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .edit-zone .properties {
+        display: flex;
+        justify-content: space-between;
+
+        margin-top: 10px;
+        margin-bottom: 10px;
+    }
+
+    input[type="text"] {
+        background: var(--pz-input-bg);
+        color: var(--text-color);
+        border: 1px solid var(--pz-input-border);
+        padding: 0.25ch 0.5ch;
+    }
+
+    .edit-btn {
+        background-color: var(--save-button-color);
+        color: var(--save-button-text);
+        padding: 0.5ch 2ch;
+        border: none;
+        border-radius: 2px;
+        cursor: pointer;
+        width: 100%;
+
+        box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
+    }
+`;
+
+// Prefer a single constructable stylesheet shared by every shadow root (parsed
+// once, not re-injected on every render). But that API is not universal —
+// Safari/iOS < 16.4 and some older HA Companion webviews lack it, and
+// `new CSSStyleSheet()` throws there. Building it at module scope would abort
+// the whole script before customElements.define() runs, leaving every
+// zone-entry inert. So detect support; render() falls back to an inline <style>
+// when the sheet is null.
+let ZONE_ENTRY_SHEET = null;
+try {
+    ZONE_ENTRY_SHEET = new CSSStyleSheet();
+    ZONE_ENTRY_SHEET.replaceSync(ZONE_ENTRY_CSS);
+} catch (_e) {
+    ZONE_ENTRY_SHEET = null;
+}
+
 // custom component that will renderder the above template
 class ZoneEntry extends HTMLElement {
-    // Custom properties cascade through shadow DOM, so the theme palette
-    // defined on :root in style.css reaches us automatically. No need to
-    // duplicate dark-mode values here.
-    styles = `
-    <style>
-        :host { color: var(--text-color); }
-
-        .hidden {
-            display: none !important;
-        }
-
-        .header {
-            display: flex;
-            justify-content: space-between;
-        }
-
-        .shape-count {
-            opacity: 0.6;
-            font-size: 0.85em;
-            font-weight: normal;
-            margin-left: 0.5ch;
-        }
-
-        .zone-entry {
-            width: 100%;
-            margin-top: 2px;
-            margin-bottom: 2px;
-
-            padding-top: 5px;
-            padding-bottom: 5px;
-        }
-
-        .zone-entry.editing {
-            margin: 5px -10px;
-            padding: 5px 10px;
-            background-color: var(--pz-edit-bg);
-        }
-
-        .zone-entry.editing .header {
-            font-weight: bold;
-        }
-
-        .edit-zone {
-            display: flex;
-            flex-direction: column;
-        }
-
-        .edit-zone .properties {
-            display: flex;
-            justify-content: space-between;
-
-            margin-top: 10px;
-            margin-bottom: 10px;
-        }
-
-        input[type="text"] {
-            background: var(--pz-input-bg);
-            color: var(--text-color);
-            border: 1px solid var(--pz-input-border);
-            padding: 0.25ch 0.5ch;
-        }
-
-        .edit-btn {
-            background-color: var(--save-button-color);
-            color: var(--save-button-text);
-            padding: 0.5ch 2ch;
-            border: none;
-            border-radius: 2px;
-            cursor: pointer;
-            width: 100%;
-
-            box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
-        }
-    </style>
-    `;
-
     constructor() {
         super();
     }
 
     connectedCallback() {
         this.attachShadow({mode: 'open'});
+        if (ZONE_ENTRY_SHEET) this.shadowRoot.adoptedStyleSheets = [ZONE_ENTRY_SHEET];
 
         // listen to changes of attributes that affect render: editing state
         // and the shape-count indicator.
@@ -111,8 +124,7 @@ class ZoneEntry extends HTMLElement {
         // rather than innerHTML interpolation so names containing HTML do not
         // execute script. The surrounding markup is static.
         this.shadowRoot.innerHTML = `
-            ${this.styles}
-
+            ${ZONE_ENTRY_SHEET ? '' : `<style>${ZONE_ENTRY_CSS}</style>`}
             <div class="zone-entry ${editing ? 'editing' : ''}">
                 <div class="header">
                     <span>
@@ -174,7 +186,14 @@ class ZoneEntry extends HTMLElement {
         this.dispatchEvent(new CustomEvent('edit', {
             bubbles: true,
             composed: true,
-            detail: {editing: !editing, name: name, oldName: this.getAttribute('name')}
+            detail: {
+                editing: !editing,
+                name: name,
+                oldName: this.getAttribute('name'),
+                // Stable per-zone id so the map can match the right layer even
+                // when two zones share a display name (rename targeting bug).
+                id: this.getAttribute('zone-id') || null,
+            }
         }));
         this.setAttribute('editing', (!editing).toString());
     }


### PR DESCRIPTION
Completes the remaining four items of #10 on top of #17.

## Changes
- **id-based layer lookup** — `zone-entry` now carries a stable `zone-id` attribute, propagated through the edit `CustomEvent` detail; `map.js` matches the layer by id first, falling back to display-name only when no id is present. Fixes a rename targeting the wrong zone when two zones share a name.
- **Visible unsaved-changes indicator** — amber dot on the Save button, toggled by `mark_dirty`/`mark_clean` via `update_dirty_indicator()`.
- **Empty vs. loading state** — distinct "No zones yet — draw one on the map to get started." empty state, plus an `aria-busy` "Loading zones…" state around the fetch and clearer error copy pointing at the add-on log.
- **Asset-size / perf** — `GZipMiddleware` (`minimum_size=1024`) compresses the vendored Leaflet payload; zone-entry styles move to a single shared constructable stylesheet (`adoptedStyleSheets`), parsed once instead of re-injected per render. **Feature-detected** with an inline `<style>` fallback so browsers without constructable stylesheets (Safari/iOS <16.4, older HA Companion webviews) still render — caught in dual review (codex).

## Verification
- Add-on suite: **140 passed, 100% line+branch coverage**.
- arm64 docker build + boot: all changed assets served; `content-encoding: gzip` confirmed on `leaflet.js`; `/zones.json` returns an empty FeatureCollection on a fresh install (empty-state path, not error); `/config.json`, `/healthz` 200.
- Dual review: Claude + codex — codex flagged the missing constructable-stylesheet fallback (now fixed) and reported no remaining regressions.

Closes #10.