### PR TITLE
Docs: refresh for v0.3.0 editor UX + correctness fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ The script auto-resumes if the PR is already merged (e.g. after a transient fail
 If you'd rather drive it by hand, push a `vX.Y.Z` git tag whose version matches the current `polygonal_zones_editor/config.yaml`:
 
 ```sh
-git tag v0.2.12
-git push origin v0.2.12
+# Replace X.Y.Z with the version in polygonal_zones_editor/config.yaml
+git tag vX.Y.Z
+git push origin vX.Y.Z
 ```
 
 [`.github/workflows/release.yml`](./.github/workflows/release.yml) takes over from there:

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -2,10 +2,12 @@
 
 Operational procedures for the release pipeline. For routine releases, use `scripts/release-merge.sh` or the `/release-merge` skill — this doc covers the failure modes.
 
+> Throughout this doc `vX.Y.Z` is a placeholder — substitute the version in `polygonal_zones_editor/config.yaml`. Don't copy the literal example versions during an incident.
+
 ## Normal release
 
 1. Merge the version-bump PR.
-2. Tag the merge commit: `git tag v0.2.19 && git push origin v0.2.19`.
+2. Tag the merge commit: `git tag vX.Y.Z && git push origin vX.Y.Z`.
 3. `.github/workflows/release.yml` runs:
    - **matrix** — resolves the version from the tag, verifies it matches `config.yaml`, verifies a `CHANGELOG.md` entry exists, generates the arch matrix.
    - **tests** — reusable call to `test.yml` (pytest + 100% line coverage gate).
@@ -22,7 +24,7 @@ Supervisor picks up the new version within minutes via its addon-update check.
 ### Tests or lint fail after tag push
 
 - Fix the bug on `main`.
-- Bump the version (`v0.2.19` → `v0.2.20`) and re-release. Do **not** move the existing tag.
+- Bump the version (a new patch, e.g. `vX.Y.Z` → `vX.Y.(Z+1)`) and re-release. Do **not** move the existing tag.
 - Leave the original tag pointing at the broken commit — its failed release run is the historical record.
 
 ### Partial-matrix publish failure
@@ -42,7 +44,8 @@ One or more arch `Publish (<arch>)` jobs fail mid-matrix (GHCR auth timeout, rat
 **Option B — immediate rollback.** Users can pin via **Supervisor → Add-ons → Polygonal Zones → ⋮ → Rebuild** after installing a previous version from the store. From a Supervisor shell:
 
 ```sh
-ha addons update polygonal_zones --version 0.2.18
+# X.Y.Z = the last known-good version (the one before the bad release)
+ha addons update polygonal_zones --version X.Y.Z
 ```
 
 You can't delete a published ghcr.io image tag via automation; users on the broken version stay on it until they update. Cut a forward-fix version and announce it.
@@ -73,9 +76,9 @@ See the session history: `test.yml` and `lint.yml` use distinct concurrency-grou
 
 The `matrix` job fails at the version-match check. The release run dies before any image is pushed.
 
-1. Delete the bad tag: `git push --delete origin v0.2.19 && git tag -d v0.2.19`.
+1. Delete the bad tag: `git push --delete origin vX.Y.Z && git tag -d vX.Y.Z`.
 2. Bump `config.yaml` on `main` (or in a PR), merge.
-3. Re-tag: `git tag v0.2.19 <merge-commit> && git push origin v0.2.19`.
+3. Re-tag: `git tag vX.Y.Z <merge-commit> && git push origin vX.Y.Z`.
 
 ### CHANGELOG entry missing for the tag
 
@@ -83,7 +86,7 @@ Same recovery as above — `matrix` job catches it and fails before `publish`. A
 
 ## Never do this
 
-- **Don't force-push a tag** to a different commit after any image has been pushed under it. `:latest` has been removed so there's no floating-tag drift risk, but re-publishing a different image under an existing `v0.2.19` tag breaks the reproducibility promise.
+- **Don't force-push a tag** to a different commit after any image has been pushed under it. `:latest` has been removed so there's no floating-tag drift risk, but re-publishing a different image under an existing `vX.Y.Z` tag breaks the reproducibility promise.
 - **Don't amend the version-bump commit** after tagging. Create a new commit + new tag.
 - **Don't merge non-version-bump PRs on top of an in-flight release.** They don't affect the release directly but they muddy the CHANGELOG if you need to cut a hotfix.
 

--- a/polygonal_zones_editor/DOCS.md
+++ b/polygonal_zones_editor/DOCS.md
@@ -13,7 +13,7 @@ All options live under **Settings → Add-ons → Polygonal Zones → Configurat
 | `zone_colour`     | string   | `purple`  | Colour used to render zones on the map (any CSS colour name or `#rrggbb`).                                                |
 | `theme`           | list     | `auto`    | `auto` follows the OS `prefers-color-scheme`. Set `light` or `dark` to override.                                          |
 | `allow_all_ips`   | bool     | `false`   | When `true`, accept HTTP requests from any IP, not just the Home Assistant ingress sidecar. See **LAN access** below.     |
-| `save_token`      | password | *(empty)* | When set, `POST /save_zones` requires `X-Save-Token: <value>` for any non-ingress request. See **Securing /save_zones**.  |
+| `save_token`      | password | *(empty)* | When set, both `GET /zones.json` (reads) and `POST /save_zones` (writes) require `X-Save-Token: <value>` for any non-ingress request. See **Securing /save_zones**. |
 | `trusted_proxies` | string   | *(empty)* | Comma-separated list of proxy IPs whose `X-Forwarded-For` header should be honoured. Leave empty unless you front the add-on with your own reverse proxy. |
 | `log_level`       | list     | `info`    | One of `debug`, `info`, `warning`, `error`, `critical`. Bump to `debug` when troubleshooting.                             |
 
@@ -36,7 +36,9 @@ Set `allow_all_ips: true` only when the companion integration runs on a **differ
 
 ### Securing `/save_zones` (`save_token`)
 
-When `save_token` is set, the add-on requires the header `X-Save-Token: <value>` on any `POST /save_zones` request that doesn't come from HA ingress. The Save button in the add-on's UI keeps working unauthenticated because it goes through ingress.
+When `save_token` is set, the add-on requires the header `X-Save-Token: <value>` on any non-ingress request — this covers **both** `GET /zones.json` (reads) **and** `POST /save_zones` (writes), not just writes. The Save button in the add-on's UI keeps working unauthenticated because it goes through ingress.
+
+The token takes precedence over `allow_all_ips`: once it's set, LAN reads and writes need the header even with `allow_all_ips: true`. So if you set a token and then a LAN `curl` of `/zones.json` returns `401`, that's expected — add the header (see below).
 
 Pick a long random string (the field is masked in the UI). To rotate, change the value and restart the add-on — there is no migration needed.
 
@@ -47,8 +49,12 @@ The token is **never** logged. The `Loaded options:` line at startup prints it a
 The zones are kept in `/data/polygonal_zones/zones.json` inside the container, but you don't need a shell to read them. If you have `allow_all_ips: true`:
 
 ```sh
-# Backup
+# Backup (no save_token set)
 curl http://<ha-host>:8000/zones.json > zones-backup.json
+
+# Backup (with save_token set — reads need the header too)
+curl -H 'X-Save-Token: <yourtoken>' \
+  http://<ha-host>:8000/zones.json > zones-backup.json
 
 # Restore (without save_token)
 curl -X POST -H 'Content-Type: application/json' \
@@ -129,7 +135,9 @@ After installing and starting the add-on, you can access the web interface in tw
 
 ### Saving changes
 
-**Important:** Any changes made to the zones need to be saved by pressing the **Save Button** located at the bottom of the sidebar. Unsaved changes will not be persisted between restarts.
+**Important:** Any changes made to the zones need to be saved by pressing the **Save** button located at the bottom of the sidebar. Unsaved changes will not be persisted between restarts.
+
+Whenever you have changes that haven't been written to disk yet, a small amber dot appears on the **Save** button. It clears once the save succeeds — so if you can see the dot, you still have unsaved work.
 
 ### Zones file
 
@@ -143,6 +151,12 @@ The zones are stored as a GeoJSON `FeatureCollection` at `http(s)://[HOST]:[PORT
 
 - A list of all the zones is displayed in the sidebar.
 - The zones are also visualized on the map.
+- While the list is loading it shows **"Loading zones…"**. On a brand-new install with no zones yet, it shows **"No zones yet — draw one on the map to get started."** If it stays stuck on "Loading zones…", check the add-on log.
+
+#### Map style
+
+- Use the **Map style** dropdown at the top of the sidebar to change the background map: **OpenStreetMap**, **CARTO Dark**, or **Esri World Imagery** (satellite).
+- **Auto** follows your Home Assistant light/dark theme.
 
 #### Adding zones
 
@@ -155,11 +169,11 @@ The zones are stored as a GeoJSON `FeatureCollection` at `http(s)://[HOST]:[PORT
 - Click the Edit Button next to a zone's name in the sidebar.
 - This will make the polygon editable on the map. Drag the points to modify the zone's shape.
 - You can also rename the zone directly in the sidebar.
-- After editing, press the Save Button next to the zone's name to save the changes.
+- When you're finished, press the **Done** button next to the zone's name. This only confirms the change in the editor — you still need to press the sidebar **Save** to write it to disk.
 
 #### Deleting zones
 
-- Click the Delete Button in the toolbar.
-- Select the zones you want to delete by clicking on them.
-- Click the Clear All Button to delete all zones at once.
-- Once you're satisfied with your selection, press the Save Button next to the delete button to confirm the deletion. Remember to also press the Save Button in the sidebar to permanently save these changes.
+- Click the Delete (trash) button in the map toolbar.
+- Select the zones you want to delete by clicking on them. (Use **Clear All** in the delete toolbar to mark every zone at once.)
+- Press **Save** in the delete toolbar to confirm the removal, or **Cancel** to back out. Note this is the map toolbar's own Save — it only updates the editor.
+- Then press the sidebar **Save** to write the change to disk.


### PR DESCRIPTION
Documentation-only refresh after the v0.3.0 release. Every factual claim verified against the code; ELI5 tone preserved.

## DOCS.md (the in-Supervisor docs tab)
- **'Done' not 'Save'** — the per-row commit button was renamed in v0.3.0; the editing steps said 'Save'. Now described correctly, clarifying it only confirms in the editor (the sidebar **Save** writes to disk). Verified in `zone-entry.js`.
- **New v0.3.0 UX documented:** the unsaved-changes **amber dot** on Save, the **'Loading zones…'** state, the **'No zones yet…'** empty state, and the **Map style** picker (OpenStreetMap / CARTO Dark / Esri satellite / Auto). Verified in `map.js` / `basemaps.js`.
- **Delete flow** reworded — the old 'Save button next to the delete button' conflated three different 'Save's; now distinguishes the delete-toolbar confirm from the sidebar write. (The delete-toolbar Save *does* exist — Leaflet-draw's remove action bar — so this is a clarity fix, not a 'button doesn't exist' fix.)
- **`save_token` gates reads too** — `GET /zones.json` from LAN needs `X-Save-Token` when a token is set (it precedes `allow_all_ips`), not just `POST /save_zones`. Documented + added a token'd backup `curl` example; the previous read example would 401. Verified in `main.py` `authorise_read`.

## README.md / RUNBOOK.md
- Replaced stale `v0.2.x` literals in the release/rollback example commands with `vX.Y.Z` placeholders (+ a note), so an incident copy-paste can't publish the wrong tag. Genuine historical version references (last 32-bit release 0.2.25, 'since 0.2.29') left intact.

## Verified-against-code, audit corrections
- The audit suggested 'drag the points to modify the shape' was wrong (toolbar has `edit:false`) — but the per-row Edit calls `layer.editing.enable()`, so it's correct; left as-is.
- The audit said the delete 'Save button' doesn't exist — it does (Leaflet-draw); reworded for clarity instead.

Dual review (Claude + codex): codex found no regressions. Add-on CI doesn't gate docs; no code/runtime change.