### PR TITLE
Release: bump add-on to 0.3.1 (tempio CVE hardening)

### DIFF
--- a/polygonal_zones_editor/CHANGELOG.md
+++ b/polygonal_zones_editor/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.1 — 2026-07-04
+
+Security-only release. No functional or contract changes.
+
+### Security
+
+- **Bundled `tempio` rebuilt to clear inherited CVEs (#21).** The stock `/usr/bin/tempio` in the HA base image (including the Alpine 3.21 base) is built against `golang.org/x/crypto` 0.26.0 on Go 1.23.3, which scanners flag for 64 CVEs (1 critical, 26 high — all in the unused `crypto/ssh` path plus Go stdlib). The Dockerfile now rebuilds tempio from a pinned upstream commit on Go 1.26 with `x/crypto` ≥ 0.52.0 and overwrites the base image's copy. Trivy reports **0 vulnerabilities** on the resulting image across OS packages, Python packages, and the tempio binary. The stage self-removes once a patched tempio ships in the base image (tracking [home-assistant/tempio#132](https://github.com/home-assistant/tempio/issues/132)).
+
 ## 0.3.0 — 2026-06-28
 
 Editor UX overhaul, a base-image platform bump (Python 3.11 → 3.12), and the nested-`schema_version` correction. No new `zones.json` contract beyond the fix below.

--- a/polygonal_zones_editor/config.yaml
+++ b/polygonal_zones_editor/config.yaml
@@ -1,6 +1,6 @@
 name: "Polygonal Zones"
 description: "Helper Add-on for the polygonal zones integration."
-version: "0.3.0"
+version: "0.3.1"
 slug: "polygonal_zones"
 url: "https://github.com/MatthewHobbs/Homeassistant-polygonal-zones-addon/tree/main/polygonal_zones_editor"
 # Image integrity: published images carry a Sigstore build-provenance


### PR DESCRIPTION
## Summary

Version-bump-only PR to ship the tempio CVE hardening merged in #21.

- `config.yaml`: `0.3.0` → `0.3.1`
- `CHANGELOG.md`: matching 0.3.1 entry (security-only release, no functional changes)

## Verification already done on the runtime change (#21)

- Local amd64 docker build on the digest-pinned 3.21 base: boots healthy, app runs as uid 1001, `/healthz` + `/zones.json` + web UI respond, rebuilt tempio renders templates.
- Trivy on the built image: **0 vulnerabilities** across OS packages, Python packages, and `/usr/bin/tempio` (stock base tempio: 64 CVEs, 1 critical).
- Dual review (Claude + codex) reconciled on #21: no correctness issues.

## Release

Merge via `/release-merge <this PR#>` — tags `v0.3.1`, release workflow re-runs Tests/Lint/Build (incl. amd64 smoke boot + Playwright) on the tagged SHA before publishing.